### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/app/assets/js/ms-admin.js
+++ b/app/assets/js/ms-admin.js
@@ -2363,7 +2363,7 @@ window.ms_init.view_settings = function init() {
             actions.each(function() {
                 var link = jQuery(this),
                     data = link.data('wpmui-ajax'),
-                    url = data.base + val;
+                    url = data.base + encodeURIComponent(val);
 
                 if (undefined === val || isNaN(val) || val < 1) {
                     link.addClass('disabled');


### PR DESCRIPTION
Potential fix for [https://github.com/cp-psource/mitgliedschaften-pro/security/code-scanning/15](https://github.com/cp-psource/mitgliedschaften-pro/security/code-scanning/15)

To fix the issue, we need to ensure that the `val` variable is sanitized or escaped before it is used in the `url` string. Since `val` is being used to construct a URL, we can use `encodeURIComponent` to escape any special characters in `val`. This will prevent malicious input from being interpreted as executable code when the `url` is assigned to the `href` attribute.

The changes will be made in the `actions.each` loop where the `url` is constructed and assigned to the `href` attribute. Specifically:
1. Use `encodeURIComponent(val)` to sanitize the `val` variable before concatenating it into the `url`.
2. Ensure that the rest of the logic remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
